### PR TITLE
tasks: when statements should not include jinja2 templating

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -7,5 +7,5 @@
     owner: "{{ cron_owner }}"
     group: "{{ cron_group }}"
     mode: "{{ cron_mode }}"
-  when: "{{ cron_jobs != false }}"
+  when: "cron_jobs != false"
   notify: restart cron

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,4 +5,4 @@
     pkg: "{{ item }}"
     state: present
   with_items: "{{ cron_packages }}"
-  when: "{{ cron_packages != false }}"
+  when: "cron_packages != false"


### PR DESCRIPTION
Hi,

I've fixed warnings from ansible, see bellow. Thanks for the best cron package for ansible btw :)

```
TASK [igor_mukhin.cron : CRON | Installing packages] ********************************************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ cron_packages != false
}}

ok: [beowulf.prod.vm] => (item=[u'cron'])

TASK [igor_mukhin.cron : CRON | Generate config] ************************************************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ cron_jobs != false }}
```